### PR TITLE
Sinon no longer builds the sinon-timers.js file

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,9 +28,7 @@ var framework = function(files) {
   /* Sinon */
   var sinonRoot = path.resolve(require.resolve('sinon'), '../../')
   var sinonPath = path.resolve(sinonRoot, 'pkg/sinon.js');
-  var sinonTimersPath = path.resolve(sinonRoot, 'pkg/sinon-timers.js');
   if (!isDuplicate(sinonPath)) {
-    files.unshift(pattern(sinonTimersPath));
     files.unshift(pattern(lolexPath));
     files.unshift(pattern(sinonPath));
   }


### PR DESCRIPTION
Thanks for the awesome karma plugin!

```
> 29 05 2016 17:01:37.736:WARN [watcher]: Pattern "/Users/tarun/Dropbox/Tracts/Shareablee/frontend-components/node_modules/sinon/pkg/sinon-timers.js" does not match any file.
```

I get the following warning when I add the `karma-sinon-chai` plugin to karma. Its because sinon stopped producing the `sinon-timers.js` file. See [sinonjs/sinon#811](https://github.com/sinonjs/sinon/issues/811)
